### PR TITLE
chore: update package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "dateformat": "~1.0.8-1.2.3",
     "chalk": "~0.4.0",
     "cli-table": "~0.3.0",
-    "lodash": "~2.4.1",
+    "lodash": "^3.10.1",
     "request": "~2.36.0",
-    "cheerio": "~0.17.0",
-    "xmlbuilder": "~2.2.1",
+    "cheerio": "~0.19.0",
+    "xmlbuilder": "^4.2.0",
     "nodemailer": "~0.7.0"
   },
   "devDependencies": {
-    "mocha": "~1.20.1",
+    "mocha": "^2.3.4",
     "chai": "~1.9.1"
   }
 }


### PR DESCRIPTION
Updated the package.json to clear the below _deprecated_ warnings.

``` shell
npm WARN engine xmlbuilder@2.2.1: wanted: {"node":"0.8.x || 0.10.x"} (current: {"node":"5.1.0","npm":"3.3.12"})
npm WARN deprecated CSSselect@0.4.1: the module is now available as 'css-select'
npm WARN deprecated CSSwhat@0.4.7: the module is now available as 'css-what'
npm WARN deprecated lodash-node@2.4.1: This package is no longer maintained. See its readme for upgrade details.
```

Updated `mocha` due to the below _deprecated_ warning:

``` shell
child_process: customFds option is deprecated, use stdio instead.
```

Build passes mocha tests set out in `test/test.js`
