### PR TITLE
Replaced deprecated gulp-util.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var es = require('event-stream');
 var Litmus = require('./lib/litmus');
 var cheerio = require('cheerio');
@@ -9,7 +9,7 @@ var dateFormat = require('dateformat');
 function sendLitmus(options){
 
 	if (!options) {
-		throw new gutil.PluginError('gulp-litmus', 'options required');
+		throw new PluginError('gulp-litmus', 'options required');
 	}
 
 	var now = new Date();
@@ -24,7 +24,7 @@ function sendLitmus(options){
 		}
 
 		if (file.isStream()) {
-			this.emit('error', new gutil.PluginError('gulp-litmus', 'Streaming not supported'));
+			this.emit('error', new PluginError('gulp-litmus', 'Streaming not supported'));
 			return cb();
 		}
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "testing"
   ],
   "dependencies": {
-    "gulp-util": "~2.2.14",
+    "plugin-error": "~1.0.1",
     "event-stream": "~3.1.5",
     "litmus-api": "~0.3.2",
     "dateformat": "~1.0.8-1.2.3",


### PR DESCRIPTION
I replaced the deprecated gulp-util packaged. Since gulp-litmus only
uses the gutil.PluginError() function it can easily be replaced by
PluginError() from the plugin-error package, which is suggested by the
gulp developers. See https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

See Issue #9.